### PR TITLE
Switch over absolute path for Resources embedding

### DIFF
--- a/PEExplorer/PEExplorer.csproj
+++ b/PEExplorer/PEExplorer.csproj
@@ -421,7 +421,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\..\..\Program Files %28x86%29\Microsoft SDKs\Expression\Blend\.NETFramework\v4.5\Libraries\Microsoft.Expression.Interactions.dll">
+    <EmbeddedResource Include="$(ProgramFiles)\Microsoft SDKs\Expression\Blend\.NETFramework\v4.5\Libraries\Microsoft.Expression.Interactions.dll">
       <Link>Assemblies\Microsoft.Expression.Interactions.dll</Link>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
The current `csproj` configuration break the build on my machine since I didn't replicate your exact folder structure.

`$(ProgramFiles)` is a Visual Studio macro always pointing towards "C:\Program Files (x86)` on my system.